### PR TITLE
[plugin.py] Correct spelling and feature name

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -282,7 +282,7 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 					self.hinttext = _('Press LEFT / RIGHT to set number of concurent streams.')
 				if not setup_exists and self.firstrun:
 					print 'U1'
-					self["information"].setText(_('Please note: DVR feature in Plex / Emby is premire feature. For more information please refer to:\nhttps://www.plex.tv/features/plex-pass\nhttps://emby.media/premiere.html'))
+					self["information"].setText(_('Please note: DVR feature in Plex / Emby is a premium / premiere feature. For more information please refer to:\nhttps://www.plex.tv/features/plex-pass\nhttps://emby.media/premiere.html'))
 					self["hinttext"].setText(_('Press OK to continue setting up.'))
 				elif setup_exists:
 					print 'U2'


### PR DESCRIPTION
The DVR feature is available in the Plex "Premium" version while for Emby it is in the "Premiere" version.

The original text has "premiere" misspelled as "premire".
