### PR TITLE
(feat) Add host config

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -9,7 +9,7 @@ import struct
 import logging
 from os import path, remove, environ as os_environ
 
-from Components.config import config, ConfigSubsection, ConfigSubDict, ConfigSelection, ConfigSelectionNumber, ConfigNumber, ConfigEnableDisable, NoSave
+from Components.config import config, ConfigSubsection, ConfigSubDict, ConfigSelection, ConfigSelectionNumber, ConfigNumber, ConfigEnableDisable, ConfigText, NoSave
 from Components.Language import language
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS, SCOPE_LANGUAGE
 
@@ -72,6 +72,7 @@ for type in tunerTypes:
 	config.hrtunerproxy.bouquets_list[type] = ConfigSelection(default=None, choices=[(None, _('Not set')), ('all', _('All'))] + getBouquetsList())
 config.hrtunerproxy.iptv_tunercount = ConfigSelectionNumber(min=1, max=10, stepwidth=1, default=2, wraparound=True)
 config.hrtunerproxy.slotsinuse = NoSave(ConfigNumber())
+config.hrtunerproxy.host = ConfigText(default="", fixed_size=False)
 config.hrtunerproxy.debug = ConfigEnableDisable(default=False)
 
 
@@ -130,6 +131,13 @@ def getIP():
 	if ifinfo:
 		IP = ifinfo['addr']
 	return '%s' % IP
+
+
+def getHost():
+	host = config.hrtunerproxy.host.value.strip()
+	if host:
+		return host
+	return getIP()
 
 
 PluginLanguageDomain = "HRTunerProxy"

--- a/plugin/getDeviceInfo.py
+++ b/plugin/getDeviceInfo.py
@@ -28,7 +28,7 @@ except:
 			return '000000'
 
 from .getLineup import getlineup
-from . import tunertypes, tunerports, tunerfolders, getIP
+from . import tunertypes, tunerports, tunerfolders, getHost
 
 charset = {
 	"auth": string.ascii_letters + string.digits,
@@ -45,8 +45,8 @@ class getDeviceInfo:
 		pass
 
 	def discoverJSON(self, dvb_type):
-		ip = getIP()
-		ip_port = 'http://%s:%s' % (ip, tunerports[dvb_type])
+		host = getHost()
+		ip_port = 'http://%s:%s' % (host, tunerports[dvb_type])
 		device_uuid = str(uuid.uuid4())
 		if path.exists('/etc/enigma2/%s.discover' % dvb_type):
 			with open('/etc/enigma2/%s.discover' % dvb_type) as data_file:

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -23,7 +23,7 @@ from Plugins.Plugin import PluginDescriptor
 from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 
-from . import _, tunerTypes, tunerfolders, tunerports, getIP, logger, isDreamOS
+from . import _, tunerTypes, tunerfolders, tunerports, getHost, logger, isDreamOS
 from .about import HRTunerProxy_About
 from .getLineup import getlineup
 from .getDeviceInfo import getdeviceinfo
@@ -135,6 +135,7 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 		Screen.setTitle(self, title)
 
 		self.savedval = config.hrtunerproxy.type.value
+		self.savedhost = config.hrtunerproxy.host.value
 
 		self.onChangedEntry = []
 		self.list = []
@@ -193,14 +194,7 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 	def LayoutFinish(self):
 		print('LayoutFinish')
 		self.createmenu()
-		if getIP() == '0.0.0.0':
-			self["information"].setText(_('WARNING: No IP address found. Please make sure you are connected to your LAN via ethernet or Wi-Fi.\n\nPress OK to exit.'))
-			self["hinttext"].hide()
-			self["key_red"].show()
-			self["button_red"].show()
-			self["closeaction"].setEnabled(True)
-		else:
-			self.populate()
+		self.populate()
 
 	def onChange(self):
 		print('onChange')
@@ -222,6 +216,7 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 	def createmenu(self):
 		self.list = []
 		self.list.append(getConfigListEntry(_('Tuner type to use.'), config.hrtunerproxy.type))
+		self.list.append(getConfigListEntry(_('IP address or hostname to use.'), config.hrtunerproxy.host))
 		self.list.append(getConfigListEntry(_('Bouquet to use.'), config.hrtunerproxy.bouquets_list[config.hrtunerproxy.type.value]))
 		if config.hrtunerproxy.type.value == 'iptv':
 			self.list.append(getConfigListEntry(_('Number of concurrent streams.'), config.hrtunerproxy.iptv_tunercount))
@@ -279,6 +274,9 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 				if currentconfig == _('Tuner type to use.'):
 					self["hinttext"].setText(_('Press OK to continue setting up this tuner or press LEFT / RIGHT to select a different tuner type.'))
 					self.hinttext = _('Press LEFT / RIGHT to select a different tuner type.')
+				elif currentconfig == _('IP address or hostname to use.'):
+					self["hinttext"].setText(_('Press OK to continue setting up this tuner or enter an IP address or hostname.'))
+					self.hinttext = _('Leave empty to use the detected IP address.')
 				elif currentconfig == _('Bouquet to use.'):
 					self["hinttext"].setText(_('Press OK to continue setting up this tuner or select a different tuner type.'))
 					self.hinttext = _('Press LEFT / RIGHT to select a different bouquet.')
@@ -300,6 +298,8 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 					if currentconfig == _('Tuner type to use.'):
 						self.hinttext = _('Press LEFT / RIGHT to select a different tuner type.')
 						print('T2')
+					elif currentconfig == _('IP address or hostname to use.'):
+						self.hinttext = _('Leave empty to use the detected IP address.')
 					elif currentconfig == _('Bouquet to use.'):
 						print('T3')
 						self.hinttext = _('Press LEFT / RIGHT to select a different bouquet.')
@@ -315,6 +315,8 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 			if currentconfig == _('Tuner type to use.'):
 				self.hinttext = _('Press LEFT / RIGHT to select a different tuner type.')
 				print('T2')
+			elif currentconfig == _('IP address or hostname to use.'):
+				self.hinttext = _('Leave empty to use the detected IP address.')
 			elif currentconfig == _('Bouquet to use.'):
 				print('T3')
 				self.hinttext = _('Press LEFT / RIGHT to select a different bouquet.')
@@ -360,6 +362,9 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 		self["button_blue"].show()
 
 	def keySave(self):
+		if getHost() == '0.0.0.0':
+			self.session.open(MessageBox, _("No IP address found. Please enter an IP address or hostname."), type=MessageBox.TYPE_ERROR)
+			return
 		if self.savedval != config.hrtunerproxy.type.value and path.exists('/etc/enigma2/%s.device' % self.savedval):
 			self.session.openWithCallback(self.saveconfirm, MessageBox, text=_("It seems you have already set up another tuner. Your server can only support one tuner type. To use this additional tuner type you will need to setup another server. Do you want to continue creating the files?"), type=MessageBox.TYPE_YESNO)
 		else:
@@ -374,9 +379,10 @@ class HRTunerProxy_Setup(ConfigListScreen, Screen):
 			if config.hrtunerproxy.debug.value:
 				logger.info('Creating files for %s' % type)
 			getdeviceinfo.write_discover(dvbtype=type)
-			if not path.exists('/etc/enigma2/%s.device' % self.savedval):
+			if not path.exists('/etc/enigma2/%s.device' % self.savedval) or self.savedhost != config.hrtunerproxy.host.value:
 				getdeviceinfo.write_device_xml(dvbtype=type)
 				config.hrtunerproxy.type.save()
+			config.hrtunerproxy.host.save()
 			config.hrtunerproxy.bouquets_list[config.hrtunerproxy.type.value].save()
 			config.hrtunerproxy.debug.save()
 			configfile.save()
@@ -419,7 +425,7 @@ def startssdp(dvbtype):
 	device_uuid = discover['DeviceUUID']
 	if config.hrtunerproxy.debug.value:
 		logger.info('Starting SSDP for %s, device_uuid: %s' % (dvbtype, device_uuid))
-	local_ip_address = getIP()
+	local_ip_address = getHost()
 	ssdp = SSDPServer()
 	ssdp.register('local',
 				  'uuid:{}::upnp:rootdevice'.format(device_uuid),

--- a/plugin/server.py
+++ b/plugin/server.py
@@ -15,7 +15,7 @@ except:
 	from SimpleHTTPServer import SimpleHTTPRequestHandler
 	from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
-from . import getIP, tunerports, porttypes, logger
+from . import getIP, getHost, tunerports, porttypes, logger
 from .getLineup import getlineup
 from .getLineupStatus import getlineupstatus
 from .getDeviceInfo import getdeviceinfo
@@ -71,7 +71,7 @@ class RootedHTTPRequestHandler(RootedBaseHTTPRequestHandler):
 			self.send_response(200)
 			self.send_header('Content-type', mimeType)
 			self.end_headers()
-			self.wfile.write(six.ensure_binary(json.dumps(getlineup.lineupdata(getIP(), tunertype, config.hrtunerproxy.bouquets_list[tunertype].value))))
+			self.wfile.write(six.ensure_binary(json.dumps(getlineup.lineupdata(getHost(), tunertype, config.hrtunerproxy.bouquets_list[tunertype].value))))
 		elif self.path.endswith("discover.json"):
 			self.send_response(200)
 			self.send_header('Content-type', mimeType)


### PR DESCRIPTION
Introduce config.hrtunerproxy.host for custom host input
Added getHost() to return host or fallback to detected IP
Updated device discovery and SSDP to use host value
Extended setup UI with host field and corresponding hints
Save host configuration and regenerate device XML if host changes